### PR TITLE
Fixed typo at wallet address on portfolio page

### DIFF
--- a/app/pages/portfolio/index.vue
+++ b/app/pages/portfolio/index.vue
@@ -10,7 +10,7 @@
                         <a class="link--default u-icon-text"
                            style="color: #fff"
                            :href="addressUrl" target="_blank" data-test-id="walletAddressLink">{{isDesktop ? address :
-                            shortAddress(address) }}</a>x
+                            shortAddress(address) }}</a>
                         <ButtonCopyIcon class="white" :copy-text="address"/>
 
                         <button class="u-icon u-icon--qr--right  u-semantic-button link--opacity" style="width: 86px"


### PR DESCRIPTION
I think the last 'x' is typo at wallet address.